### PR TITLE
Added missing dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ zmq
 redis
 pika
 cloudpickle
-dataclasses
+dataclasses;python_version<"3.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ zmq
 redis
 pika
 cloudpickle
+dataclasses


### PR DESCRIPTION
On executing `tq --help` after installation
In `job.py`:
Line 11: import dataclasses
gives error
```
ModuleNotFoundError: No module named 'dataclasses'
```